### PR TITLE
README.md: Reformat the instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,20 @@
 [Mojo](https://github.com/domokit/mojo) must be setup and `$MOJO_DIR` must point to it.
 
 ## To run
-1. `pub upgrade`
-2. `pub run sky_tools build && pub run sky_tools run_mojo --mojo-path $MOJO_DIR/src/mojo/devtools/common/mojo_run --android --mojo-debug -- --enable-multiprocess --map-origin="https://mydartapp.mojoapps.io/=$PWD" --args-for="https://mydartapp.mojoapps.io/packages/syncbase/mojo_services/android/syncbase_server.mojo --v=1 --logtostderr=true --root-dir=/data/data/org.chromium.mojo.shell/app_home/syncbasedata" --no-config-file --free-host-ports`
+```
+pub upgrade
+pub run sky_tools build && \
+pub run sky_tools run_mojo \
+  --mojo-path $MOJO_DIR/src/mojo/devtools/common/mojo_run \
+  --android \
+  --mojo-debug \
+  -- \
+  --enable-multiprocess \
+  --map-origin="https://mydartapp.mojoapps.io/=$PWD" \
+  --args-for="https://mydartapp.mojoapps.io/packages/syncbase/mojo_services/android/syncbase_server.mojo --root-dir=/data/data/org.chromium.mojo.shell/app_home/syncbasedata" \
+  --no-config-file \
+  --free-host-ports
+```
+
+### To see logs from the [V23](https://v.io) framework
+`adb logcat *:S vlog:*`


### PR DESCRIPTION
Also, remove the --logtostderr flag. No longer required since
https://github.com/cosnicolaou/llog/pull/1
was merged in.

To see logs from the vanadium runtime:
adb logcat _:S vlog:_
